### PR TITLE
fix(subtitles): handle bitmap subtitle formats correctly

### DIFF
--- a/src/test/ffmpeg-command.test.ts
+++ b/src/test/ffmpeg-command.test.ts
@@ -504,7 +504,7 @@ describe('FFmpeg Command Generation', () => {
       expect(command.args).not.toContain('-sn');
     });
 
-    it('should convert subtitles to ASS when format is PGS', () => {
+    it('should copy subtitles when format is PGS (bitmap format)', () => {
       const pgsConfig: FFmpegJobConfig = {
         inputFile: 'input.mkv',
         outputFile: 'output.mp4',
@@ -514,13 +514,12 @@ describe('FFmpeg Command Generation', () => {
       };
 
       const command = generateFFmpegCommand(pgsConfig);
-      const csIndex = command.args.indexOf('-c:s');
-      expect(csIndex).toBeGreaterThan(-1);
-      expect(command.args[csIndex + 1]).toBe('ass');
+      expect(command.args).toContain('-c:s');
+      expect(command.args).toContain('copy');
       expect(command.args).not.toContain('-sn');
     });
 
-    it('should convert subtitles to ASS when format is VOBSUB', () => {
+    it('should copy subtitles when format is VOBSUB (bitmap format)', () => {
       const vobsubConfig: FFmpegJobConfig = {
         inputFile: 'input.mkv',
         outputFile: 'output.mp4',
@@ -530,9 +529,8 @@ describe('FFmpeg Command Generation', () => {
       };
 
       const command = generateFFmpegCommand(vobsubConfig);
-      const csIndex = command.args.indexOf('-c:s');
-      expect(csIndex).toBeGreaterThan(-1);
-      expect(command.args[csIndex + 1]).toBe('ass');
+      expect(command.args).toContain('-c:s');
+      expect(command.args).toContain('copy');
       expect(command.args).not.toContain('-sn');
     });
 
@@ -550,31 +548,63 @@ describe('FFmpeg Command Generation', () => {
       expect(command.args).not.toContain('-c:s');
     });
 
-    it('should copy when all subtitle streams are compatible (mixed ASS and SRT)', () => {
+    it('should convert to ASS when all subtitle streams are text-based (mixed ASS and SRT)', () => {
       const mixedConfig: FFmpegJobConfig = {
         inputFile: 'input.mkv',
         outputFile: 'output.mp4',
         options: basicOptions,
-        jobName: 'Mixed Compatible Subtitles Test',
+        jobName: 'Mixed Text Subtitles Test',
         subtitleCodecs: ['ass', 'srt', 'subrip'],
       };
 
       const command = generateFFmpegCommand(mixedConfig);
+      const csIndex = command.args.indexOf('-c:s');
+      expect(csIndex).toBeGreaterThan(-1);
+      expect(command.args[csIndex + 1]).toBe('ass');
+      expect(command.args).not.toContain('-sn');
+    });
+
+    it('should copy when mixing bitmap and text subtitles', () => {
+      const mixedIncompatibleConfig: FFmpegJobConfig = {
+        inputFile: 'input.mkv',
+        outputFile: 'output.mp4',
+        options: basicOptions,
+        jobName: 'Mixed Bitmap and Text Subtitles Test',
+        subtitleCodecs: ['ass', 'hdmv_pgs_subtitle'],
+      };
+
+      const command = generateFFmpegCommand(mixedIncompatibleConfig);
       expect(command.args).toContain('-c:s');
       expect(command.args).toContain('copy');
       expect(command.args).not.toContain('-sn');
     });
 
-    it('should convert to ASS when one subtitle stream is incompatible', () => {
-      const mixedIncompatibleConfig: FFmpegJobConfig = {
-        inputFile: 'input.mkv',
-        outputFile: 'output.mp4',
+    it('should convert mov_text to ASS (text-based format)', () => {
+      const movTextConfig: FFmpegJobConfig = {
+        inputFile: 'input.mp4',
+        outputFile: 'output.mkv',
         options: basicOptions,
-        jobName: 'Mixed Incompatible Subtitles Test',
-        subtitleCodecs: ['ass', 'hdmv_pgs_subtitle'],
+        jobName: 'mov_text Subtitle Test',
+        subtitleCodecs: ['mov_text'],
       };
 
-      const command = generateFFmpegCommand(mixedIncompatibleConfig);
+      const command = generateFFmpegCommand(movTextConfig);
+      const csIndex = command.args.indexOf('-c:s');
+      expect(csIndex).toBeGreaterThan(-1);
+      expect(command.args[csIndex + 1]).toBe('ass');
+      expect(command.args).not.toContain('-sn');
+    });
+
+    it('should convert webvtt to ASS (text-based format)', () => {
+      const webvttConfig: FFmpegJobConfig = {
+        inputFile: 'input.webm',
+        outputFile: 'output.mkv',
+        options: basicOptions,
+        jobName: 'WebVTT Subtitle Test',
+        subtitleCodecs: ['webvtt'],
+      };
+
+      const command = generateFFmpegCommand(webvttConfig);
       const csIndex = command.args.indexOf('-c:s');
       expect(csIndex).toBeGreaterThan(-1);
       expect(command.args[csIndex + 1]).toBe('ass');
@@ -591,8 +621,9 @@ describe('FFmpeg Command Generation', () => {
       };
 
       const command = generateFFmpegCommand(uppercaseConfig);
-      expect(command.args).toContain('-c:s');
-      expect(command.args).toContain('copy');
+      const csIndex = command.args.indexOf('-c:s');
+      expect(csIndex).toBeGreaterThan(-1);
+      expect(command.args[csIndex + 1]).toBe('ass');
       expect(command.args).not.toContain('-sn');
     });
   });


### PR DESCRIPTION
## Summary

Fixes FFmpeg subtitle conversion errors when processing bitmap subtitle formats (PGS, VOBSUB).

## Problem

Previously, the code attempted to convert bitmap subtitles to ASS text format, which caused FFmpeg to fail with:
```
Subtitle encoding currently only possible from text to text or bitmap to bitmap
```

## Solution

Implemented smarter subtitle handling based on format detection:

- **Bitmap subtitles** (PGS, VOBSUB, DVDSUB) → Copy as-is (`-c:s copy`)
  - Cannot convert bitmap to text, so preserve them in original format
  
- **Text-only subtitles** (ASS, SSA, SRT, mov_text, WebVTT) → Convert to ASS (`-c:s ass`)
  - Handles container incompatibilities (e.g., mov_text in MKV)
  - ASS preserves styling better than SRT
  
- **Mixed bitmap + text** or **unknown formats** → Copy (`-c:s copy`)
  - Safest option to avoid conversion errors

## Additional Changes

- Added support for `mov_text` and `webvtt` text-based subtitle formats
- All subtitle streams are preserved (multiple subtitle tracks maintained)
- Updated tests to cover all subtitle format scenarios

## Test Plan

- [x] All 195 tests pass
- [x] Bitmap subtitle formats (PGS, VOBSUB) are copied
- [x] Text subtitle formats (mov_text, webvtt) are converted to ASS
- [x] Mixed formats default to copy mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)