### PR TITLE
Add minimum release age requirement for package installations

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,5 +1,9 @@
 # Bun configuration file
 
+[install]
+# Only install package versions published at least 7 days ago
+minimumReleaseAge = 604800
+
 [test]
 # Preload happy-dom and testing library setup
 preload = ["./happydom.ts", "./testing-library.ts", "./src/test/setup.ts"]


### PR DESCRIPTION
## Summary
Added a configuration option to require that installed packages have been published at least 7 days ago, improving stability by avoiding very recent package releases that may contain undiscovered bugs.

## Changes
- Added `[install]` section to `bunfig.toml` with `minimumReleaseAge = 604800` (7 days in seconds)
- This configuration ensures that only package versions with a minimum age of 7 days are installed during dependency resolution

## Implementation Details
This leverages Bun's built-in package installation configuration to enforce a safety window for dependencies. The 604800 second value (7 days) provides a reasonable buffer to catch issues in newly released packages before they're used in this project.

https://claude.ai/code/session_011SGLWNvgoXFrjtYxep6hjt